### PR TITLE
Simplify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ categories = [
 
 [dependencies]
 chrono = "0.4.19"
-gdnative = "0.9.3"
+gdnative-core = "0.9.3"
 log = "0.4.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! [Godot]: https://godotengine.org/
 
 use chrono::Local;
-use gdnative::{godot_print, godot_warn};
+use gdnative_core::{godot_print, godot_warn};
 use log::{Level, Log, Metadata, Record, SetLoggerError};
 
 static LOGGER: GodotLogger = GodotLogger;


### PR DESCRIPTION
godot-logger does not need to include all of gdnative, and can instead
rely on the much smaller gdnative-core crate that exports the macros
that godot-logger uses.