### PR TITLE
Set up tooling to craft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+---
+name: Release
+
+"on":
+  release:
+    types: [published]
+
+jobs:
+  crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache build artifacts
+        uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-stable-cargo-v1-${{ hashFiles('Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-stable-cargo-v1-
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CRATES_TOKEN}} -v --all-features

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -1,0 +1,29 @@
+---
+name: Shell
+
+"on": [push]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Lint code with Shellcheck
+        uses: ludeeus/action-shellcheck@1.1.0
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.3.4
+
+      - name: Run shfmt
+        uses: luizm/action-sh-checker@v0.3.0
+        with:
+          sh_checker_shellcheck_disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Implement simple logger that prints messages to the output console in Godot

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ categories = [
 chrono = "0.4.19"
 gdnative-core = "0.9.3"
 log = "0.4.14"
+
+[dev-dependencies]
+gdnative = "0.9.3"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,30 @@ _Logger for [godot-rust] projects_
 `godot-logger` is a logger implementation for [godot-rust] projects that prints
 logs using [`godot_print!`].
 
+## Usage
+
+Add [`godot-logger`] and [`log`] as dependencies to `Cargo.toml`.
+
+Then initialize `godot-logger` in the `init` function that is exported by
+`gdnative`
+
+```rust
+use gdnative::prelude::*;
+
+fn init(handle: InitHandle) {
+    godot_logger::init(Level::Debug);
+    log::debug!("Initialized the logger");
+}
+
+godot_init!(init);
+```
+
+The following will be printed in the _Output_ console inside Godot:
+
+```text
+2021-09-25 19:29:25 DEBUG Initialized the logger
+```
+
 ## License
 
 Licensed under either of
@@ -20,5 +44,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
+[`godot-logger`]: https://crates.io/crates/godot-logger
 [`godot_print!`]: https://docs.rs/gdnative/latest/gdnative/macro.godot_print.html
 [godot-rust]: https://godot-rust.github.io
+[`log`]: https://crates.io/crates/log

--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Enable strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+if [ $# -ne 1 ]; then
+	echo "Usage: ./prepare-release <next_version>"
+	exit 1
+fi
+
+next_version=$1
+current_git_tag="$(git tag -l "v*" | sort | tail -n 1)"
+current_version="$(echo "$current_git_tag" | cut -c 2-)"
+
+if [[ -z "$current_version" ]]; then
+	echo "Failed to get latest version. Aborting"
+	exit 2
+fi
+
+echo "Current version: ${current_version}"
+echo "Next version:    ${next_version}"
+read -p "Continue? [y/n] " -n 1 -r
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+	exit 3
+fi
+
+echo
+
+bin_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+root_directory="$(cd "${bin_directory}/.." || exit 4 && pwd)"
+
+# Update version
+echo "Bumping version..."
+
+files=(
+	"Cargo.toml"
+	"README.md"
+)
+
+for file in "${files[@]}"; do
+	vim -c "%s/${current_version}/${next_version}/g" -c "wq" "${root_directory}/${file}"
+done
+
+# Updating changelog
+echo "Updating changelog..."
+vim "${root_directory}/CHANGELOG.md"
+
+# Commit changes
+echo "Committing changes..."
+git checkout -b "release-${next_version}" >/dev/null 2>&1
+git add . >/dev/null 2>&1
+git commit -m "Release ${next_version}" >/dev/null 2>&1
+
+echo
+echo "Release of version ${next_version} prepared. Push the branch, open a pull"
+echo "request, and wait for review. Once merged, create a new release on GitHub."
+echo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,32 @@
 //! [Godot] game engine. It is built around the logging facade of the [`log`] crate, and uses the
 //! [`godot_print!`] macro from the [`gdnative`] bindings.
 //!
+//! # Use
+//!
+//! Add [`godot-logger`] and [`log`] as dependencies to `Cargo.toml`.
+//!
+//! Then initialize `godot-logger` in the `init` function that is exported by `gdnative`.
+//!
+//! ```no_run
+//! use gdnative::prelude::*;
+//! use log::Level;
+//!
+//! fn init(handle: InitHandle) {
+//!     godot_logger::init(Level::Debug);
+//!     log::debug!("Initialized the logger");
+//! }
+//!
+//! godot_init!(init);
+//! ```
+//!
+//! The following will appear in the _Output_ console inside Godot:
+//!
+//! ```text
+//! 2021-09-25 19:29:25 DEBUG Initialized the logger
+//! ```
+//!
 //! [`gdnative`]: https://crates.io/crates/gdnative
+//! [`godot-logger`]: https://crates.io/crates/godot-logger
 //! [`godot_print!`]: https://docs.rs/gdnative/latest/gdnative/macro.godot_print.html
 //! [`log`]: https://crates.io/crates/log
 //! [Godot]: https://godotengine.org/


### PR DESCRIPTION
The process to craft and cut new releases has been mostly automated
using a script and a GitHub Action. The only manual action required is
to update the changelog.