### PR TITLE
Include module name in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD024 -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -6,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Include module name in log output
 
 ## [0.1.0] - 2021-09-25
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Then initialize `godot-logger` in the `init` function that is exported by
 
 ```rust
 use gdnative::prelude::*;
+use log::Level;
 
 fn init(handle: InitHandle) {
     godot_logger::init(Level::Debug);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,17 +56,19 @@ impl Log for GodotLogger {
     }
 
     fn log(&self, record: &Record) {
-        let message = format!(
-            "{} {} {}",
-            Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
-            record.level(),
-            record.args()
-        );
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let level = record.level();
+        let message = record.args();
+
+        let output = match record.module_path() {
+            Some(module) => format!("{} {} {} {}", timestamp, level, module, message),
+            None => format!("{} {} {}", timestamp, level, message),
+        };
 
         if record.level() <= Level::Warn {
-            godot_warn!("{}", message);
+            godot_warn!("{}", output);
         } else {
-            godot_print!("{}", message);
+            godot_print!("{}", output);
         }
     }
 


### PR DESCRIPTION
The module name is now included in each line that is logged inside
Godot. This makes it much easier to attribute specific log lines to the
line of code that printed them.