### PR TITLE
Measure test coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,7 +82,18 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Run tests
-        uses: actions-rs/cargo@v1
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@master
         with:
-          command: test
+          version: 0.18.2
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: code-coverage-report
+          path: cobertura.xml


### PR DESCRIPTION
In an effort to increase the quality of the library, its test coverage
is now being measured during CI builds. The test coverage is reported to
Codecov, which posts a summary of each change in the corresponding pull
request.

Due to limitations in Tarpaulin, the library used to measure the test
coverage, doc tests and integration tests do not count towards the
coverage.