### PR TITLE
Change to a builder-style interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `init` now accepts a list of module-level overrides
+- Replace `init` function with a builder pattern
 
 ## [0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,29 @@ logs using [`godot_print!`].
 
 ## Usage
 
-Add [`godot-logger`] and [`log`] as dependencies to `Cargo.toml`.
+Start by adding [`godot-logger`] and [`log`] as dependencies to your project's
+`Cargo.toml`.
 
-Then initialize `godot-logger` in the `init` function that is exported by
-`gdnative`
+```toml
+[dependencies]
+godot-logger = "0.2.0"
+log = "0.4"
+```
+
+Then configure and initialize the logger in the `init` method that is passed to
+`godot_init!`.
 
 ```rust
 use gdnative::prelude::*;
-use log::Level;
+use godot_logger::{Filter, GodotLogger};
+use log::{Level, LevelFilter};
 
 fn init(handle: InitHandle) {
-    godot_logger::init(Level::Debug);
+    GodotLogger::builder()
+        .default_log_level(Level::Warn)
+        .add_filter(Filter::new("godot_logger", LevelFilter::Debug))
+        .init();
+
     log::debug!("Initialized the logger");
 }
 
@@ -27,7 +39,7 @@ godot_init!(init);
 The following will be printed in the _Output_ console inside Godot:
 
 ```text
-2021-09-25 19:29:25 DEBUG Initialized the logger
+2021-09-25 19:29:25 DEBUG godot-logger Initialized the logger
 ```
 
 ## License

--- a/src/appender.rs
+++ b/src/appender.rs
@@ -1,0 +1,34 @@
+use chrono::Local;
+use gdnative_core::{godot_print, godot_warn};
+use log::{Level, Record};
+use log4rs::append::Append;
+
+/// A log appender for `log4rs` that prints to Godot's output console
+///
+/// [godot-logger] uses [log4rs] under the hood to configure the logger. A custom appender has been
+/// created to write log records to Godot's output console.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub(crate) struct GodotAppender;
+
+impl Append for GodotAppender {
+    fn append(&self, record: &Record) -> anyhow::Result<()> {
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let level = record.level();
+        let message = record.args();
+
+        let output = match record.module_path() {
+            Some(module) => format!("{} {} {} {}", timestamp, level, module, message),
+            None => format!("{} {} {}", timestamp, level, message),
+        };
+
+        if record.level() <= Level::Warn {
+            godot_warn!("{}", output);
+        } else {
+            godot_print!("{}", output);
+        }
+
+        Ok(())
+    }
+
+    fn flush(&self) {}
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,167 @@
+use log::{Level, SetLoggerError};
+use log4rs::config::{Appender, Logger, Root};
+use log4rs::Config;
+
+use crate::appender::GodotAppender;
+use crate::Filter;
+
+const APPENDER_NAME: &str = "godot-logger";
+
+/// A `Builder` that configures and initializes the Godot logger
+///
+/// [godot-logger] implements the builder pattern as the primary interface to configure and
+/// initialize the logger. The configuration has sensible defaults that can be overwritten by
+/// calling the corresponding setters on the `Builder` struct. Once the configuration is done, the
+/// logger can be initialized by calling the `build` method.
+///
+/// # Examples
+///
+/// ```
+/// use log::Level;
+/// use godot_logger::GodotLogger;
+///
+/// GodotLogger::builder()
+///     .default_log_level(Level::Debug)
+///     .init();
+/// ```
+///
+/// [godot-logger]: https://crates.io/crates/godot-logger
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Builder {
+    default_log_level: Level,
+    filters: Vec<Filter>,
+}
+
+impl Builder {
+    /// Sets the default log level
+    ///
+    /// `GodotLogger` matches all log records against a default log level. By default, only warnings
+    /// and errors are logged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use log::Level;
+    /// use godot_logger::GodotLogger;
+    ///
+    /// let mut builder = GodotLogger::builder();
+    /// builder = builder.default_log_level(Level::Debug);
+    /// ```
+    pub fn default_log_level(mut self, default_log_level: Level) -> Self {
+        self.default_log_level = default_log_level;
+        self
+    }
+
+    /// Adds a filter
+    ///
+    /// Filters override the default log level for specific Rust modules.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use godot_logger::{Filter, GodotLogger};
+    /// use log::LevelFilter;
+    ///
+    /// let mut builder = GodotLogger::builder();
+    /// let filter = Filter::new("godot_logger", LevelFilter::Off);
+    ///
+    /// builder = builder.add_filter(filter);
+    /// ```
+    pub fn add_filter(mut self, filter: Filter) -> Self {
+        self.filters.push(filter);
+        self
+    }
+
+    /// Initializes the logger
+    ///
+    /// This method consumes the builder and initializes the logger with the current configuration
+    /// of the builder. After calling this method, log records will be written to Godot's output
+    /// console.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use log::Level;
+    /// use godot_logger::GodotLogger;
+    ///
+    /// GodotLogger::builder().init();
+    /// ```
+    pub fn init(self) -> Result<(), SetLoggerError> {
+        let loggers: Vec<Logger> = self
+            .filters
+            .iter()
+            .map(|filter| {
+                Logger::builder()
+                    .appender(APPENDER_NAME)
+                    .build(filter.module(), filter.level())
+            })
+            .collect();
+
+        let config = Config::builder()
+            .appender(Appender::builder().build(APPENDER_NAME, Box::new(GodotAppender)))
+            .loggers(loggers)
+            .build(
+                Root::builder()
+                    .appender(APPENDER_NAME)
+                    .build(self.default_log_level.to_level_filter()),
+            )
+            .unwrap();
+
+        let _handle = log4rs::init_config(config)?;
+        Ok(())
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            default_log_level: Level::Warn,
+            filters: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use log::{Level, LevelFilter};
+
+    use crate::Filter;
+
+    use super::Builder;
+
+    #[test]
+    fn default_log_level() {
+        let mut builder = Builder::default();
+
+        builder = builder.default_log_level(Level::Debug);
+
+        assert!(matches!(builder.default_log_level, Level::Debug));
+    }
+
+    #[test]
+    fn add_filter() {
+        let mut builder = Builder::default();
+
+        builder = builder.add_filter(Filter::new("godot_logger::builder", LevelFilter::Off));
+
+        assert_eq!(builder.filters.len(), 1);
+    }
+
+    #[test]
+    fn trait_default() {
+        let builder = Builder::default();
+        assert!(matches!(builder.default_log_level, Level::Warn));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Builder>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Builder>();
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,82 @@
+use log::LevelFilter;
+
+/// A filter applies a custom log level to a Rust module
+///
+/// Logs in [godot-logger] can be filtered using the default log level or a module-level override.
+/// Module-level overrides are configured using a `Filter`, which combines a module path in Rust
+/// with a log level.
+///
+/// # Example
+///
+/// ```
+/// use godot_logger::Filter;
+/// use log::LevelFilter;
+///
+/// let filter = Filter::new("godot-logger", LevelFilter::Off);
+/// ```
+///
+/// [godot-logger]: https://crates.io/crates/godot-logger
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Filter {
+    module: &'static str,
+    level: LevelFilter,
+}
+
+impl Filter {
+    /// Initializes a new `Filter`
+    ///
+    /// Filters combine a module path in Rust with a log level, and are used to set a log level for
+    /// a specific module.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use godot_logger::Filter;
+    /// use log::LevelFilter;
+    ///
+    /// let filter = Filter::new("godot-logger", LevelFilter::Off);
+    /// ```
+    pub fn new(module: &'static str, level: LevelFilter) -> Self {
+        Self { module, level }
+    }
+
+    /// Returns the filter's module path
+    pub fn module(&self) -> &'static str {
+        self.module
+    }
+
+    /// Returns the filter's log level
+    pub fn level(&self) -> LevelFilter {
+        self.level
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Filter;
+    use log::LevelFilter;
+
+    #[test]
+    fn module() {
+        let filter = Filter::new("godot_logger::filter", LevelFilter::Debug);
+        assert_eq!(filter.module(), "godot_logger::filter");
+    }
+
+    #[test]
+    fn level() {
+        let filter = Filter::new("godot_logger::filter", LevelFilter::Debug);
+        assert!(matches!(filter.level(), LevelFilter::Debug));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Filter>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Filter>();
+    }
+}


### PR DESCRIPTION
The crate's interface has been refactored from an `init` method to a
builder struct. This provides a more intuitive way to configure the
logger, and hides some of its complexities.