### PR TITLE
Remove Filter from the crate's public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `Filter` from the crate's public interface
+
 ## [0.3.0]
 
 ### Changed

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,9 @@
-use log::{Level, SetLoggerError};
+use log::{Level, LevelFilter, SetLoggerError};
 use log4rs::config::{Appender, Logger, Root};
 use log4rs::Config;
 
 use crate::appender::GodotAppender;
-use crate::Filter;
+use crate::filter::Filter;
 
 const APPENDER_NAME: &str = "godot-logger";
 
@@ -59,16 +59,13 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// use godot_logger::{Filter, GodotLogger};
+    /// use godot_logger::GodotLogger;
     /// use log::LevelFilter;
     ///
-    /// let mut builder = GodotLogger::builder();
-    /// let filter = Filter::new("godot_logger", LevelFilter::Off);
-    ///
-    /// builder = builder.add_filter(filter);
+    /// GodotLogger::builder().add_filter("godot_logger", LevelFilter::Off);
     /// ```
-    pub fn add_filter(mut self, filter: Filter) -> Self {
-        self.filters.push(filter);
+    pub fn add_filter(mut self, module: &'static str, level: LevelFilter) -> Self {
+        self.filters.push(Filter::new(module, level));
         self
     }
 
@@ -125,8 +122,6 @@ impl Default for Builder {
 mod tests {
     use log::{Level, LevelFilter};
 
-    use crate::Filter;
-
     use super::Builder;
 
     #[test]
@@ -142,7 +137,7 @@ mod tests {
     fn add_filter() {
         let mut builder = Builder::default();
 
-        builder = builder.add_filter(Filter::new("godot_logger::builder", LevelFilter::Off));
+        builder = builder.add_filter("godot_logger::builder", LevelFilter::Off);
 
         assert_eq!(builder.filters.len(), 1);
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,18 +6,9 @@ use log::LevelFilter;
 /// Module-level overrides are configured using a `Filter`, which combines a module path in Rust
 /// with a log level.
 ///
-/// # Example
-///
-/// ```
-/// use godot_logger::Filter;
-/// use log::LevelFilter;
-///
-/// let filter = Filter::new("godot-logger", LevelFilter::Off);
-/// ```
-///
 /// [godot-logger]: https://crates.io/crates/godot-logger
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct Filter {
+pub(crate) struct Filter {
     module: &'static str,
     level: LevelFilter,
 }
@@ -27,15 +18,6 @@ impl Filter {
     ///
     /// Filters combine a module path in Rust with a log level, and are used to set a log level for
     /// a specific module.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use godot_logger::Filter;
-    /// use log::LevelFilter;
-    ///
-    /// let filter = Filter::new("godot-logger", LevelFilter::Off);
-    /// ```
     pub fn new(module: &'static str, level: LevelFilter) -> Self {
         Self { module, level }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@
 //!
 //! ```
 //! use gdnative::prelude::*;
-//! use godot_logger::{Filter, GodotLogger};
+//! use godot_logger::GodotLogger;
 //! use log::{Level, LevelFilter};
 //!
 //! fn init(handle: InitHandle) {
 //!     GodotLogger::builder()
-//!         .default_log_level(Level::Debug)
-//!         .add_filter(Filter::new("godot_logger", LevelFilter::Off))
+//!         .default_log_level(Level::Info)
+//!         .add_filter("godot_logger", LevelFilter::Debug)
 //!         .init();
 //!     log::debug!("Initialized the logger");
 //! }
@@ -34,7 +34,7 @@
 //! The following will appear in the _Output_ console inside Godot:
 //!
 //! ```text
-//! 2021-09-25 19:29:25 DEBUG godot-logger Initialized the logger
+//! 2021-09-25 19:29:25 DEBUG godot_logger Initialized the logger
 //! ```
 //!
 //! [env_logger]: https://crates.io/crates/env_logger
@@ -46,7 +46,6 @@
 //! [Godot]: https://godotengine.org/
 
 pub use crate::builder::*;
-pub use crate::filter::*;
 
 mod appender;
 mod builder;
@@ -65,11 +64,12 @@ mod filter;
 ///
 /// ```
 /// use godot_logger::GodotLogger;
-/// use log::Level;
+/// use log::{Level, LevelFilter};
 ///
 /// // Configure and initialize the logger
 /// GodotLogger::builder()
 ///     .default_log_level(Level::Debug)
+///     .add_filter("godot-logger", LevelFilter::Warn)
 ///     .init();
 /// ```
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]


### PR DESCRIPTION
The `Filter` struct has been removed from the crate's public interface.
After reviewing the crate's API, it became clear that the filter does
not offer any substantial benefit over simply passing a module path and
level filter to the builder. By hiding the filter, the public interface
gets cleaned up and the crate gets easier to use.